### PR TITLE
Containerize for the beep platform

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.github
+node_modules
+dist
+*.tsbuildinfo
+.env*
+!.env.example
+.DS_Store

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,49 @@
+# Builds the site image on push to master and publishes to GHCR.
+# Repo settings: Settings → Actions → General → Workflow permissions = "Read and write".
+name: publish
+
+on:
+  push:
+    branches: [master]
+    tags:    ['v*']
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE:    ${{ github.repository }}   # arriw/home
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha,format=short
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to:   type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# Static site (Vite + React + TS) served by nginx.
+# Build stage compiles to /app/dist; runtime stage serves it.
+
+FROM node:22-alpine AS builder
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --no-audit --no-fund
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine AS runtime
+COPY --from=builder /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s \
+  CMD wget -qO- http://127.0.0.1/ >/dev/null 2>&1 || exit 1

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,10 @@
+server {
+  listen 80;
+  root /usr/share/nginx/html;
+  index index.html;
+
+  # SPA fallback — mirrors netlify.toml /* → /index.html.
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+}


### PR DESCRIPTION
## Summary
- Multi-stage Dockerfile: Vite build → nginx:alpine runtime
- nginx.conf with SPA fallback (mirrors the netlify.toml redirect rule)
- GHCR publish workflow on push to master → ghcr.io/arriw/home:latest
- Wires this repo up to the beep platform service catalog at ~/stash/beep/

Once merged, the publish workflow runs and beep can pull the image:
\`\`\`
cd ~/stash/beep && pwsh ./scripts/up.ps1 home
\`\`\`

## Test plan
- [ ] Merge → `publish` workflow runs green
- [ ] `ghcr.io/arriw/home:latest` exists
- [ ] `./scripts/up.ps1 home` brings up beep-home + beep-home-ts
- [ ] https://home.tail699d2d.ts.net/ serves the site

🤖 Generated with [Claude Code](https://claude.com/claude-code)